### PR TITLE
Unify internal variables in "create"

### DIFF
--- a/src/CronAlarms.cpp
+++ b/src/CronAlarms.cpp
@@ -207,22 +207,29 @@ time_t CronClass::getNextTrigger(CronID_t ID) const
   }
 }
 
+// attempt to create a cron alarm at the specified CronID
+void CronClass::create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
+{
+  free(ID);
+  const char* err = NULL;
+  memset(&(Alarm[id].expr), 0, sizeof(Alarm[id].expr));
+  cron_parse_expr(cronstring, &(Alarm[id].expr), &err);
+  if (err) {
+    memset(&(Alarm[id].expr), 0, sizeof(Alarm[id].expr));
+    return dtINVALID_ALARM_ID;
+  }
+  Alarm[id].onTickHandler = onTickHandler;
+  Alarm[id].isOneShot = isOneShot;
+  enable(id);
+}
+
 // attempt to create a cron alarm and return CronID if successful
 CronID_t CronClass::create(const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
 {
   for (uint8_t id = 0; id < dtNBR_ALARMS; id++) {
     if (!isAllocated(id)) {
       // here if there is an Alarm id that is not allocated
-      const char* err = NULL;
-      memset(&(Alarm[id].expr), 0, sizeof(Alarm[id].expr));
-      cron_parse_expr(cronstring, &(Alarm[id].expr), &err);
-      if (err) {
-        memset(&(Alarm[id].expr), 0, sizeof(Alarm[id].expr));
-        return dtINVALID_ALARM_ID;
-      }
-      Alarm[id].onTickHandler = onTickHandler;
-      Alarm[id].isOneShot = isOneShot;
-      enable(id);
+      create(id, cronstring, onTickHandler, isOneShot);
       return id;  // alarm created ok
     }
   }

--- a/src/CronAlarms.cpp
+++ b/src/CronAlarms.cpp
@@ -208,7 +208,7 @@ time_t CronClass::getNextTrigger(CronID_t ID) const
 }
 
 // attempt to create a cron alarm at the specified CronID
-void CronClass::create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
+CronID_t CronClass::create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
 {
   free(ID);
   const char* err = NULL;
@@ -221,6 +221,7 @@ void CronClass::create(CronID_t ID, const char * cronstring, OnTick_t onTickHand
   Alarm[id].onTickHandler = onTickHandler;
   Alarm[id].isOneShot = isOneShot;
   enable(id);
+  return id;
 }
 
 // attempt to create a cron alarm and return CronID if successful

--- a/src/CronAlarms.h
+++ b/src/CronAlarms.h
@@ -57,7 +57,7 @@ public:
   CronClass();
 
   // Function to create alarms and timers with cron
-  void create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
+  CronID_t create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   CronID_t create(const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   // isOneShot - trigger once at the given time in the future
 

--- a/src/CronAlarms.h
+++ b/src/CronAlarms.h
@@ -57,7 +57,7 @@ public:
   CronClass();
 
   // Function to create alarms and timers with cron
-  CronID_t create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
+  void create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   CronID_t create(const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   // isOneShot - trigger once at the given time in the future
 

--- a/src/CronAlarms.h
+++ b/src/CronAlarms.h
@@ -57,6 +57,7 @@ public:
   CronClass();
 
   // Function to create alarms and timers with cron
+  CronID_t create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   CronID_t create(const char * cronstring, OnTick_t onTickHandler, bool isOneShot);
   // isOneShot - trigger once at the given time in the future
 


### PR DESCRIPTION
CronID_t CronClass::create(CronID_t ID, const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
{
  free(ID);

Switch to:
CronID_t CronClass::create(CronID_t id, const char * cronstring, OnTick_t onTickHandler, bool isOneShot)
{
  free(id);