### PR TITLE
add std::function callback option

### DIFF
--- a/src/CronAlarms.cpp
+++ b/src/CronAlarms.cpp
@@ -172,7 +172,11 @@ void CronClass::serviceAlarms()
           Alarm[servicedCronId].updateNextTrigger();
         }
         if (TickHandler != NULL) {
+#ifdef USE_STD_FUNCTION_CALLBACK
+          TickHandler();     // call the handler
+#else
           (*TickHandler)();     // call the handler
+#endif
         }
       }
     }

--- a/src/CronAlarms.h
+++ b/src/CronAlarms.h
@@ -28,7 +28,12 @@ typedef CronID_t CronId;  // Arduino friendly name
 #define dtINVALID_ALARM_ID 255
 #define dtINVALID_TIME     (time_t)(-1)
 
+#ifdef USE_STD_FUNCTION_CALLBACK
+#include <functional>
+typedef std::function<void()> OnTick_t;
+#else
 typedef void (*OnTick_t)();  // alarm callback function typedef
+#endif
 
 // class defining an alarm instance, only used by dtAlarmsClass
 class CronEventClass


### PR DESCRIPTION
Add a macro option to allow std:function as callbacks, disabled by default.